### PR TITLE
Add WAI-ARIA support

### DIFF
--- a/lib/add-list-element.js
+++ b/lib/add-list-element.js
@@ -1,5 +1,6 @@
 import mouseDownHandler from "./mouse-down-handler.js";
 import removeListElement from "./remove-list-element.js";
+import getNextId from "./get-next-id.js";
 
 export default addListElement;
 
@@ -10,8 +11,14 @@ function addListElement(state, select) {
   removeListElement(state);
 
   const list = document.createElement("plete-list");
+  list.setAttribute("id", getNextId("plete-list"));
+
+  state.plete.setAttribute("aria-expanded", "true");
+
+  state.input.setAttribute("aria-controls", list.getAttribute("id"));
 
   list.setAttribute("style", getStyles(input));
+  list.setAttribute("aria-role", "listbox");
 
   if (state.cssClass) {
     list.setAttribute("class", state.cssClass);

--- a/lib/clear-suggestions.js
+++ b/lib/clear-suggestions.js
@@ -5,4 +5,6 @@ export default clearSuggestions;
 function clearSuggestions(state) {
   state.selectedIndex = -1;
   removeListElement(state);
+  state.input.removeAttribute("aria-controls");
+  state.plete.setAttribute("aria-expanded", "false");
 }

--- a/lib/ensure-plete-element.js
+++ b/lib/ensure-plete-element.js
@@ -1,0 +1,14 @@
+export default ensurePleteElement;
+
+function ensurePleteElement(state) {
+  state.plete = state.input.closest("plete");
+
+  if (!state.plete) {
+    state.plete = document.createElement("plete");
+    state.input.parentNode.appendChild(state.plete);
+    state.plete.appendChild(state.input);
+  }
+
+  state.plete.setAttribute("aria-role", "combobox");
+  state.plete.setAttribute("aria-expanded", "false");
+}

--- a/lib/get-next-id.js
+++ b/lib/get-next-id.js
@@ -1,0 +1,14 @@
+export default getNextId;
+
+/**
+ * Used for generating DOM ids that will never repeat
+ * @param  {string} prefix A prefix to use for the first part of the string
+ * @return {string}        A DOM id
+ */
+function getNextId(prefix) {
+  getNextId.id++;
+
+  return `${prefix}-${getNextId.id}`;
+}
+
+getNextId.id = -1;

--- a/lib/main.css
+++ b/lib/main.css
@@ -1,3 +1,11 @@
+plete {
+  display: inline;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+}
+
 plete-list {
   position: absolute;
   overflow: hidden;

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,6 +1,7 @@
 import attachEventListeners from "./attach-event-listeners.js";
 import validateOptions from "./validate-options.js";
 import ensurePleteElement from "./ensure-plete-element.js";
+import setAutoComplete from "./set-auto-complete.js";
 
 export default Plete;
 
@@ -20,6 +21,7 @@ function Plete(options) {
   const state = Object.assign({}, DEFAULT_OPTIONS, options);
 
   validateOptions(state);
+  setAutoComplete(state);
   ensurePleteElement(state);
   attachEventListeners(state);
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,5 +1,6 @@
 import attachEventListeners from "./attach-event-listeners.js";
 import validateOptions from "./validate-options.js";
+import ensurePleteElement from "./ensure-plete-element.js";
 
 export default Plete;
 
@@ -19,5 +20,6 @@ function Plete(options) {
   const state = Object.assign({}, DEFAULT_OPTIONS, options);
 
   validateOptions(state);
+  ensurePleteElement(state);
   attachEventListeners(state);
 }

--- a/lib/render-item.js
+++ b/lib/render-item.js
@@ -2,6 +2,8 @@ export default renderItem;
 
 function renderItem(state, value) {
   const item = document.createElement("plete-item");
+  item.setAttribute("aria-role", "option");
+
   const valueIsString = typeof value === "string";
   const attrValue = valueIsString ? value : value.id;
   const label = valueIsString ? value : value.label;

--- a/lib/set-auto-complete.js
+++ b/lib/set-auto-complete.js
@@ -1,0 +1,5 @@
+export default setAutoComplete;
+
+function setAutoComplete(state) {
+  state.input.setAttribute("aria-autocomplete", "list");
+}

--- a/test/aria-support.test.js
+++ b/test/aria-support.test.js
@@ -14,6 +14,12 @@ describe("Plete", function() {
       });
     });
 
+    it("sets `aria-autocomplete` attribute to `list` on the input", function(){
+        const input = setupTest();
+
+        assert.equals(input.getAttribute("aria-autocomplete"), "list");
+    });
+
     context("when suggestions are visible", function() {
       beforeEach(async function() {
         this.input = setupTest();

--- a/test/aria-support.test.js
+++ b/test/aria-support.test.js
@@ -1,0 +1,78 @@
+import { assert } from "@sinonjs/referee-sinon";
+import { fireEvent, waitForElement } from "@testing-library/dom";
+import { setupTest } from "./test-helper";
+
+describe("Plete", function() {
+  describe("WAI-ARIA support", function() {
+    it("ensures a plete element with `aria-role` of combobox", async function() {
+      [true, false].forEach(function(value) {
+        const input = setupTest({ existingPlete: value });
+        const plete = input.closest("plete");
+
+        assert.equals(plete.getAttribute("aria-role"), "combobox");
+        assert.equals(plete.getAttribute("aria-expanded"), "false");
+      });
+    });
+
+    context("when suggestions are visible", function() {
+      beforeEach(async function() {
+        this.input = setupTest();
+
+        this.input.value = "a";
+        fireEvent.input(this.input, {
+          key: "a"
+        });
+
+        this.list = await waitForElement(() =>
+          document.querySelector("plete-list")
+        );
+      });
+
+      it("sets `aria-controls` attribute on input to id of <plete-list>", function() {
+        assert.equals(this.input.getAttribute("aria-controls"), this.list.id);
+      });
+
+      it("renders the list items with `aria-role` of `option`", function() {
+        const listItems = this.list.querySelectorAll("plete-item");
+
+        assert.isTrue(listItems.length > 0);
+        listItems.forEach(function(item) {
+          assert.equals(item.getAttribute("aria-role"), "option");
+        });
+      });
+
+      it("sets `aria-expanded` on the `plete` element to 'true'", function() {
+        const plete = this.input.closest("plete");
+
+        assert.equals(plete.getAttribute("aria-expanded"), "true");
+      });
+    });
+
+    context("when suggestions are hidden", function() {
+      it("removes `aria-controls` attribute on input", async function() {
+        this.input = setupTest();
+
+        this.input.value = "a";
+        fireEvent.input(this.input, {
+          key: "a"
+        });
+
+        this.list = await waitForElement(() =>
+          document.querySelector("plete-list")
+        );
+
+        fireEvent.keyDown(this.input, {
+          key: "Escape"
+        });
+
+        assert.equals(this.input.getAttribute("aria-controls"), null);
+      });
+
+      it("sets `aria-expanded` on the `plete` element to 'false'", function() {
+        const plete = this.input.closest("plete");
+
+        assert.equals(plete.getAttribute("aria-expanded"), "false");
+      });
+    });
+  });
+});

--- a/test/test-helper.js
+++ b/test/test-helper.js
@@ -35,18 +35,22 @@ function getOptions(overrides) {
   return Object.assign({}, defaults, overrides);
 }
 
-function setupTest(overrides = {}) {
+function setupTest(overrides = { existingPlete: false }) {
   document.body.innerHTML = "";
 
   const form = document.createElement("form");
   document.body.appendChild(form);
+
+  const parent = overrides.existingPlete
+    ? form.appendChild(document.createElement("plete"))
+    : form;
 
   const input = document.createElement("input");
   input.type = "text";
   input.id = "plete";
   input.tabIndex = 1;
 
-  form.appendChild(input);
+  parent.appendChild(input);
 
   // this is needed to be able to test moving focus away from the autocompleted input
   const focusableElement = document.createElement("input");


### PR DESCRIPTION
This PR aims to implement WAI-ARIA, as specified for `combobox` role in WAI-ARIA 1.1.

#### Background

See: https://www.w3.org/TR/wai-aria-1.2/#combobox

#### Solution

* Add a containing element `<plete>` as a parent/ancestor of the input
* Set `aria-role` to `combobox` on `<plete>`
* Set  `aria-expanded` to `false` on `<plete>` when no suggestions are visible
* Set  `aria-expanded` to `true`  on `<plete>` when suggestions are visible
* Set `aria-autocomplete` to `list` in the input element
* Set `aria-controls` on the input to the `id` of the `<plete-list>` element, when suggestions are visible
* Remove `aria-controls` attribute on the input, when no suggestions are visible
* Set `aria-role` to `option` on `<plete-item>` elements


#### How to verify

1. Have I interpreted https://www.w3.org/TR/wai-aria-1.2/#combobox correctly?
1. Read the code
1. Run the example locally with `npm ci && npm start`
1. Navigate to http://localhost:8080
1. Inspect the DOM as you type in the input elements