### PR TITLE
Fix #6: escape input string on local filter

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -5,7 +5,12 @@ async function filter(state) {
 
   if (Array.isArray(state.dataSrc)) {
     // search for all the characters individually
-    const string = inputValue.split("").join(".*");
+    const string = inputValue
+      .split("")
+      .map(function(c) {
+        return "\\" + c;
+      })
+      .join(".*");
     const regex = new RegExp(string, "i");
 
     if (typeof state.dataSrc[0] === "string") {

--- a/lib/filter.test.js
+++ b/lib/filter.test.js
@@ -3,6 +3,22 @@ import { assert } from "@sinonjs/referee-sinon";
 import filter from "./filter.js";
 
 describe("filter", function() {
+  context("when used with Array dataSrc", function() {
+    // https://github.com/mroderick/plete/issues/6
+    it("escapes the input query", async function() {
+      const state = {
+        input: {
+          value: "S.a.n"
+        },
+        dataSrc: ["Denmark", "Germany", "Spain", "Sweden", "United Kingdom"]
+      };
+
+      const result = await filter(state);
+
+      assert.equals(result, []);
+    });
+  });
+
   context("when used with a non-Array, non-Function dataSrc", function() {
     it("throws an Error", async function() {
       const state = {


### PR DESCRIPTION
This PR fixes #6 by escaping the input string for local filtering.