### PR TITLE
Unit test suggest.js

### DIFF
--- a/lib/proxyquire-helper.js
+++ b/lib/proxyquire-helper.js
@@ -1,0 +1,7 @@
+import proxyquire from "proxyquire";
+
+export { loadDefault };
+
+function loadDefault(module, config) {
+  return proxyquire.noCallThru().load(module, config).default;
+}

--- a/lib/state-helper.js
+++ b/lib/state-helper.js
@@ -1,0 +1,14 @@
+import { sinon } from "@sinonjs/referee-sinon";
+export { getState };
+
+function getState(overrides) {
+  return Object.assign(
+    {
+      input: {
+        value: "val"
+      },
+      dataSrc: sinon.fake.resolves
+    },
+    overrides
+  );
+}

--- a/lib/suggest.test.js
+++ b/lib/suggest.test.js
@@ -1,0 +1,33 @@
+import { assert, sinon } from "@sinonjs/referee-sinon";
+import { loadDefault } from "./proxyquire-helper.js";
+import { getState } from "./state-helper.js";
+
+const filterResult = ["1654642f-d476-4e3c-9ea5-1359b7258889"];
+const fakeClearSuggestion = sinon.fake();
+const fakeFilter = sinon.fake.resolves(filterResult);
+const fakeRender = sinon.fake();
+const fakeSelect = sinon.fake();
+
+const suggest = loadDefault("./suggest.js", {
+  "./clear-suggestions.js": fakeClearSuggestion,
+  "./filter": fakeFilter,
+  "./render": fakeRender,
+  "./select": fakeSelect
+});
+
+describe("suggest", function() {
+  it("is a unary Function named 'suggest'", function() {
+    assert.hasArity(suggest, 1);
+    assert.equals(suggest.name, "suggest");
+  });
+
+  context("when filter returns a promise", function() {
+    it("calls render with the data of the promise", async function() {
+      const state = getState();
+
+      await suggest(state);
+
+      assert.calledWith(fakeRender, state, filterResult);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -2560,6 +2560,16 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "~1.0.1",
+        "merge-descriptors": "~1.0.0"
+      }
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -4048,6 +4058,12 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
     "is-observable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
@@ -5101,6 +5117,29 @@
       "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
       "dev": true
     },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "merge-source-map": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+      "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5424,6 +5463,12 @@
           }
         }
       }
+    },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -6366,6 +6411,23 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "proxyquire": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
+      "dev": true,
+      "requires": {
+        "fill-keys": "^1.0.2",
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
+      }
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "psl": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^15.0.0",
     "prettier": "^1.19.1",
+    "proxyquire": "^2.1.3",
     "rollup": "^1.27.11",
     "rollup-plugin-terser": "^5.1.3"
   },


### PR DESCRIPTION
This PR scaffolds unit test for `suggest`, using `proxyquire` to stub out dependencies.

Once this is merged, we can improve the unit test coverage of `suggest` in preparation of expanding on it later.