### PR TITLE
Don't use eslint-plugin-compat for tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -355,7 +355,8 @@ module.exports = {
         "mocha/no-skipped-tests": "error",
         "mocha/no-top-level-hooks": "error",
 
-        "this/no-this": "off"
+        "this/no-this": "off",
+        "compat/compat": "off"
       }
     }
   ]


### PR DESCRIPTION
We're only running the tests in LTS Node, so don't need to test for
problems in legacy browsers for the test files.

Source files will still be checked by eslint-plugin-compat