### PR TITLE
Add support for cancelling

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,5 +162,72 @@
         });
       </script>
     </section>
+
+    <section id="cancel">
+      <form action=".">
+        <fieldset>
+          <h2>Cancel remote requests</h2>
+          <label>
+            Country
+            <input type="text" name="country" autocomplete="off" autofocus="autofocus" />
+          </label>
+        </fieldset>
+      </form>
+      <p>
+        You selected: <span class="selectedValue"></span>
+      </p>
+      <script type="module">
+        import Plete from "./dist/main-esm.js";
+
+        function dataSrc(query) {
+          const controller = new AbortController();
+          const promise = filterCountriesWithCancellation(query, controller.signal);
+          const abort = controller.abort.bind(controller);
+
+          return {
+            promise,
+            abort
+          }
+        }
+
+        async function filterCountriesWithCancellation(query, signal) {
+          const defaultResult = [];
+          try {
+            const response = await fetch(`https://restcountries.eu/rest/v2/name/${query}`, { signal });
+            const countries = await response.json();
+
+            if (!Array.isArray(countries)) {
+              return defaultResult;
+            }
+
+            return mapCountriesToPleteData(countries);
+          } catch (error) {
+            if (error.name === 'AbortError') {
+              console.log("Previous request aborted");
+              return defaultResult;
+            }
+
+            throw error;
+          }
+        }
+
+        function mapCountriesToPleteData(countries) {
+          return countries.map(function(v) {
+            return {
+              id: v.alpha3Code,
+              label: v.name
+            };
+          });
+        }
+
+        const plete = new Plete({
+          input: document.querySelector("#cancel input[name='country']"),
+          dataSrc: dataSrc,
+          select: function(id) {
+            document.querySelector("#cancel .selectedValue").textContent = id;
+          }
+        });
+      </script>
+    </section>
   </body>
 </html>

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -1,6 +1,6 @@
 export default filter;
 
-async function filter(state) {
+function filter(state) {
   const inputValue = state.input.value;
 
   if (Array.isArray(state.dataSrc)) {

--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -21,11 +21,23 @@ async function suggest(state) {
     return;
   }
 
-  const filteredData = await filter(state);
+  const filteredData = await getPromise(filter(state));
   const data = filteredData.slice(0, state.maxItems);
 
   render(state, data);
   notifyReady(state);
+}
+
+function getPromise(filterResult) {
+  if (filterResult instanceof Promise) {
+    return filterResult;
+  }
+
+  if (filterResult.promise instanceof Promise) {
+    return filterResult.promise;
+  }
+
+  return filterResult;
 }
 
 function notifyBusy(state) {

--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -21,7 +21,13 @@ async function suggest(state) {
     return;
   }
 
-  const filteredData = await getPromise(filter(state));
+  abortRequest(state);
+
+  const filterResult = filter(state);
+  saveAbortFunction(state, filterResult);
+
+  const filteredData = await getPromise(filterResult);
+
   const data = filteredData.slice(0, state.maxItems);
 
   render(state, data);
@@ -38,6 +44,23 @@ function getPromise(filterResult) {
   }
 
   return filterResult;
+}
+
+function abortRequest(state) {
+  if (!state.abortCurrentRequest) {
+    return;
+  }
+
+  state.abortCurrentRequest();
+  delete state.abortCurrentRequest;
+}
+
+function saveAbortFunction(state, filterResult) {
+  if (!filterResult.abort) {
+    return;
+  }
+
+  state.abortCurrentRequest = filterResult.abort;
 }
 
 function notifyBusy(state) {

--- a/lib/suggest.test.js
+++ b/lib/suggest.test.js
@@ -2,27 +2,61 @@ import { assert, sinon } from "@sinonjs/referee-sinon";
 import { loadDefault } from "./proxyquire-helper.js";
 import { getState } from "./state-helper.js";
 
-const filterResult = ["1654642f-d476-4e3c-9ea5-1359b7258889"];
-const fakeClearSuggestion = sinon.fake();
-const fakeFilter = sinon.fake.resolves(filterResult);
-const fakeRender = sinon.fake();
-const fakeSelect = sinon.fake();
-
-const suggest = loadDefault("./suggest.js", {
-  "./clear-suggestions.js": fakeClearSuggestion,
-  "./filter": fakeFilter,
-  "./render": fakeRender,
-  "./select": fakeSelect
-});
-
 describe("suggest", function() {
   it("is a unary Function named 'suggest'", function() {
+    const suggest = loadDefault("./suggest", {});
+
     assert.hasArity(suggest, 1);
     assert.equals(suggest.name, "suggest");
   });
 
   context("when filter returns a promise", function() {
+    before(function() {
+      this.filterResult = ["1654642f-d476-4e3c-9ea5-1359b7258889"];
+      const fakeClearSuggestion = sinon.fake();
+      const fakeFilter = sinon.fake.resolves(this.filterResult);
+      this.fakeRender = sinon.fake();
+      const fakeSelect = sinon.fake();
+
+      this.suggest = loadDefault("./suggest.js", {
+        "./clear-suggestions.js": fakeClearSuggestion,
+        "./filter": fakeFilter,
+        "./render": this.fakeRender,
+        "./select": fakeSelect
+      });
+    });
+
     it("calls render with the data of the promise", async function() {
+      const { fakeRender, filterResult, suggest } = this;
+      const state = getState();
+
+      await suggest(state);
+
+      assert.calledWith(fakeRender, state, filterResult);
+    });
+  });
+
+  context("when filter returns an object", function() {
+    before(function() {
+      this.filterResult = ["1654642f-d476-4e3c-9ea5-1359b7258889"];
+      const fakeClearSuggestion = sinon.fake();
+      const fakeFilter = sinon.fake.returns({
+        promise: Promise.resolve(this.filterResult),
+        abort: sinon.fake()
+      });
+      this.fakeRender = sinon.fake();
+      const fakeSelect = sinon.fake();
+
+      this.suggest = loadDefault("./suggest.js", {
+        "./clear-suggestions.js": fakeClearSuggestion,
+        "./filter": fakeFilter,
+        "./render": this.fakeRender,
+        "./select": fakeSelect
+      });
+    });
+
+    it("calls render with the data of the promise", async function() {
+      const { fakeRender, filterResult, suggest } = this;
       const state = getState();
 
       await suggest(state);

--- a/test/datasrc-as-function.test.js
+++ b/test/datasrc-as-function.test.js
@@ -1,0 +1,46 @@
+import { assert, refute, sinon } from "@sinonjs/referee-sinon";
+import { fireEvent } from "@testing-library/dom";
+import { setupTest } from "./test-helper";
+
+describe("dataSrc is function", function() {
+  beforeEach(function() {
+    document.body.innerHTML = "";
+  });
+
+  context("when it returns an object", function() {
+    // This tests needs to be refactored to use Sinon's clock, so to not depend on setTimeout
+    it("calls abort function of previous object", function(done) {
+      const LONGER_THAN_DEBOUNCE = 121;
+
+      const abort = sinon.fake();
+      const input = setupTest({
+        dataSrc: sinon.fake.returns({
+          promise: Promise.resolve(["4855337c-cbea-4360-8163-71c48edd4aa7"]),
+          abort
+        })
+      });
+
+      input.value = "aaa";
+      fireEvent.input(input, {
+        key: "a"
+      });
+
+      // wait for the debounce before making the second event,
+      // or it will be the only event
+      setTimeout(function() {
+        refute.called(abort);
+
+        input.value = "aab";
+        fireEvent.input(input, {
+          key: "b"
+        });
+
+        // then wait for another debounce, before checking if the abort has been called
+        setTimeout(function() {
+          assert.calledOnce(abort);
+          done();
+        }, LONGER_THAN_DEBOUNCE);
+      }, LONGER_THAN_DEBOUNCE);
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes #5 

#### Background

When filtering using remote services, it can be beneficial to cancel requests, especially when the network is unstable and responses appear out of order.

Aborting old requests, mean that only the last request will be used.

#### Solution

With the changes in the PR, the `dataSrc` functions can return an object with `promise` and `abort` properties, in addition to the existing promise.

The `abort` function will be called before the next call to the `dataSrc` function.

Abandoned solution: We tried implementing this using an array returned from `dataSrc`. However, that makes it difficult to differentiate between the situations, where we want to use an `abort` function, and when the `dataSrc` returns an array of results. Using an object with named properties, makes it easy to detect the `abort` scenario.

An example with aborting has been added to the `index.html` file, which is for development purposes.

Once this PR is merged, we can cut a new `minor` version, and update the documentation site.

#### How to verify

1. Check out this branch
1. `npm ci`
1. `npm start`
1. Navigate to http://localhost:8080
1. In the "Cancel remote requests" example type several values (note that the input is debounced to 120ms, so fast typing will only generate one request)
1. Observe that `Previous request aborted` is logged to the console when requests are aborted