### PR TITLE
Fix missing main.css in dev-mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <!-- use a blank favicon, so we don't have to see the 404 requests in the network tab -->
     <link href="data:image/x-icon;base64,AAABAAEAEBAQAAAAAAAoAQAAFgAAACgAAAAQAAAAIAAAAAEABAAAAAAAgAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAsC8qAP+EAACzh1cAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAACAAAAAAAAACAAAAAAAAEiAAAAADAAAiAAAAAAMzAiAAAAAAAAMzAAAAAAAAAiMzMAAAAAAAADAzAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD//wAA//8AAP//AAD//wAA//8AAP//AAD//wAA//8AAP//AAD//wAA//8AAP//AAD//wAA//8AAP//AAD//wAA" rel="icon" type="image/x-icon" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.css" crossorigin="anonymous">
-    <link rel="stylesheet" href="./dist/main.css" />
+    <link rel="stylesheet" href="./lib/main.css" />
     <style>
       body {
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";


### PR DESCRIPTION
This PR fixes #29 

#### Background

When running in dev mode, `index.html` would load up the `main.css` from
the `dist` folder.

The `dist/main.css` file would only exist, if the `build` script had
been run previously.

That shouldn't be necessary for development. Also, loading it from
`dist/` would mean that it could get out of date.

#### Solution

Since the `http-server` part of the `start` script is serving up the
entire repository from the root, we can use `main.css` from `lib/`
directly.

#### How to verify

1. Check out this branch
1. `git clean -fdx`
1. `npm ci`
1. `npm start`
1. Navigate to http://localhost:8080
1. Observe that the CSS is loaded