### PR TITLE
Convenience: fetch with AbortController

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,5 +229,41 @@
         });
       </script>
     </section>
+
+    <section id="fetch-with-cancellation">
+      <form action=".">
+        <fieldset>
+          <h2>Fetch with cancellation</h2>
+          <label>
+            Country
+            <input type="text" name="country" autocomplete="off" autofocus="autofocus" />
+          </label>
+        </fieldset>
+      </form>
+      <p>
+        You selected: <span class="selectedValue"></span>
+      </p>
+      <script type="module">
+        import pleteWithFetchAndAbort from "./lib/plete-with-fetch-and-abort.js";
+
+        function mapCountriesToPleteData(countries) {
+          return countries.map(function(v) {
+            return {
+              id: v.alpha3Code,
+              label: v.name
+            };
+          });
+        }
+
+        const plete800 = pleteWithFetchAndAbort({
+          input: document.querySelector("#fetch-with-cancellation input[name='country']"),
+          mapData: mapCountriesToPleteData,
+          select: function(id) {
+            document.querySelector("#fetch-with-cancellation .selectedValue").textContent = id;
+          },
+          urlTemplate: "https://restcountries.eu/rest/v2/name/{query}"
+        });
+      </script>
+    </section>
   </body>
 </html>

--- a/lib/add-abort-signal.js
+++ b/lib/add-abort-signal.js
@@ -1,0 +1,20 @@
+export default addAbortSignal;
+
+const AbortController = window.AbortController;
+const RUNTIME_HAS_ABORTCONTROLLER = Boolean(AbortController);
+
+/**
+ * Returns a new options object, with a `signal` property added, when the
+ * runtime supports the AbortController
+ *
+ * @param  {object} options existing fetch options
+ * @return {object}      improved fetch options
+ */
+function addAbortSignal(options) {
+  const signalOptions = RUNTIME_HAS_ABORTCONTROLLER && {
+    // eslint-disable-next-line compat/compat
+    signal: new AbortController().signal
+  };
+
+  return Object.assign({}, options, signalOptions);
+}

--- a/lib/add-abort-signal.test.js
+++ b/lib/add-abort-signal.test.js
@@ -1,0 +1,45 @@
+import { assert, sinon } from "@sinonjs/referee-sinon";
+import { loadDefault } from "./proxyquire-helper.js";
+
+describe("addAbortSignal", function() {
+  afterEach(function() {
+    sinon.restore();
+  });
+
+  context("when the runtime supports AbortController", function() {
+    before(function() {
+      const fakeSignal = "9db48960-74b0-4bde-b7de-81a57c8784fd";
+      const fakeAbortController = sinon.fake.returns({
+        signal: fakeSignal
+      });
+
+      sinon.replace(window, "AbortController", fakeAbortController);
+
+      this.fakeSignal = fakeSignal;
+    });
+
+    it("returns an object with a signal", function() {
+      const addAbortSignal = loadDefault("./add-abort-signal.js", {});
+
+      const options = {};
+      const result = addAbortSignal(options);
+
+      assert.equals(result.signal, this.fakeSignal);
+    });
+  });
+
+  context("when the runtime does not support AbortController", function() {
+    before(function() {
+      sinon.stub(window, "AbortController").value(undefined);
+    });
+
+    it("returns an object without a signal", function() {
+      const addAbortSignal = loadDefault("./add-abort-signal.js", {});
+
+      const options = {};
+      const result = addAbortSignal(options);
+
+      assert.isUndefined(result.signal);
+    });
+  });
+});

--- a/lib/fetch-data-src.js
+++ b/lib/fetch-data-src.js
@@ -1,0 +1,20 @@
+import addAbortSignal from "./add-abort-signal.js";
+import processResponse from "./process-response.js";
+
+export default fetchDataSrc;
+
+function fetchDataSrc(fetch, urlTemplate, mapData, fetchOptions, query) {
+  const defaultResult = [];
+  const url = urlTemplate.replace("{query}", query);
+  const promise = fetch(url, addAbortSignal(fetchOptions));
+
+  try {
+    return processResponse(promise, mapData, defaultResult);
+  } catch (error) {
+    if (error.name === "AbortError") {
+      return defaultResult;
+    }
+
+    throw error;
+  }
+}

--- a/lib/fetch-data-src.test.js
+++ b/lib/fetch-data-src.test.js
@@ -1,0 +1,115 @@
+import { sinon, assert } from "@sinonjs/referee-sinon";
+import { loadDefault } from "./proxyquire-helper.js";
+
+function prepareTest(
+  t,
+  error,
+  result = "48cf68ea-91f4-4945-9e74-ab6fc8c27287"
+) {
+  t.fakeAddAbortSignal = sinon.fake.returns(
+    "84e73b2b-b234-49f6-b411-7e05c245a6e3"
+  );
+  t.fakeProcessResponse = error
+    ? sinon.fake.throws(error)
+    : sinon.fake.returns(result);
+  t.fetchDataSrc = loadDefault("./fetch-data-src.js", {
+    "./add-abort-signal.js": t.fakeAddAbortSignal,
+    "./process-response.js": t.fakeProcessResponse
+  });
+}
+
+describe("fetchDataSrc", function() {
+  after(function() {
+    sinon.restore();
+  });
+
+  it("calls fetch with fetchOptions", function() {
+    prepareTest(this);
+    const fakeFetch = sinon.fake.resolves(
+      "caf721e7-cca2-4def-b71c-a5ea09b9c91c"
+    );
+    const urlTemplate = "{query}";
+    const mapData = sinon.fake();
+    const fetchOptions = {};
+    const query = "00becaa8-936b-43cc-9af4-7cf396c037d6";
+
+    this.fetchDataSrc(fakeFetch, urlTemplate, mapData, fetchOptions, query);
+
+    assert.calledOnce(fakeFetch);
+    assert.calledWith(
+      fakeFetch,
+      query,
+      this.fakeAddAbortSignal.returnValues[0]
+    );
+  });
+
+  it("returns the processed response", function() {
+    prepareTest(this);
+    const fakeFetch = sinon.fake.resolves(
+      "caf721e7-cca2-4def-b71c-a5ea09b9c91c"
+    );
+    const urlTemplate = "{query}";
+    const mapData = sinon.fake();
+    const fetchOptions = {};
+    const query = "00becaa8-936b-43cc-9af4-7cf396c037d6";
+
+    const result = this.fetchDataSrc(
+      fakeFetch,
+      urlTemplate,
+      mapData,
+      fetchOptions,
+      query
+    );
+
+    assert.equals(result, this.fakeProcessResponse.returnValues[0]);
+  });
+
+  context("when a request is aborted", function() {
+    it("returns an empty array", function() {
+      const error = new Error();
+      error.name = "AbortError";
+      prepareTest(this, error);
+      const fakeFetch = sinon.fake.resolves(
+        "caf721e7-cca2-4def-b71c-a5ea09b9c91c"
+      );
+      const urlTemplate = "{query}";
+      const mapData = sinon.fake();
+      const fetchOptions = {};
+      const query = "00becaa8-936b-43cc-9af4-7cf396c037d6";
+
+      const result = this.fetchDataSrc(
+        fakeFetch,
+        urlTemplate,
+        mapData,
+        fetchOptions,
+        query
+      );
+      assert.equals(result, []);
+    });
+  });
+
+  context("when process response throws", function() {
+    it("re-throws the same error", function() {
+      const errorMessage = "e2ac030f-ef6f-48a3-a3d0-11af9e41d8c2";
+      const error = new Error(errorMessage);
+      prepareTest(this, error);
+      const fakeFetch = sinon.fake.resolves(
+        "caf721e7-cca2-4def-b71c-a5ea09b9c91c"
+      );
+      const urlTemplate = "{query}";
+      const mapData = sinon.fake();
+      const fetchOptions = {};
+      const query = "00becaa8-936b-43cc-9af4-7cf396c037d6";
+      const t = this;
+
+      assert.exception(
+        function() {
+          t.fetchDataSrc(fakeFetch, urlTemplate, mapData, fetchOptions, query);
+        },
+        {
+          message: errorMessage
+        }
+      );
+    });
+  });
+});

--- a/lib/plete-with-fetch-and-abort.js
+++ b/lib/plete-with-fetch-and-abort.js
@@ -1,0 +1,64 @@
+import Plete from "./plete.js";
+import fetchDataSrc from "./fetch-data-src.js";
+
+export default pleteWithFetchAndAbort;
+
+const DEFAULT_OPTIONS = {
+  urlTemplate: undefined,
+  mapData: identity
+};
+
+/* istanbul ignore next  */
+function identity(data) {
+  return data;
+}
+
+/**
+ * Returns a Plete object that uses `fetch` as the dataSrc.
+ *
+ * When AbortController is supported, it will be use to abort existing
+ * requests to avoid out-of-order problems.
+ *
+ * @param  {object} options This object will be passed through to the Plete constructor and can thus receive the same
+ *                          properties
+ * @param  {string} options.urlTemplate - A template for the url, using "{query}" as a token to be replaced with what
+ *                                        the user types
+ * @param  {function} [options.mapData] - Optional function that transforms the reponse data to the Plete data format.
+ *                                        When omitted, the response data passes through as-is.
+ *
+ * @return {object}         A Plete instance
+ */
+function pleteWithFetchAndAbort(options) {
+  const opts = Object.assign({}, DEFAULT_OPTIONS, options);
+  const urlTemplate = opts.urlTemplate;
+  const mapData = opts.mapData;
+  const fetchOptions = opts.fetchOptions;
+
+  if (typeof urlTemplate !== "string" || !urlTemplate.includes("{query}")) {
+    throw new TypeError(
+      "urlTemplate option expected to be a string containing '{query}'"
+    );
+  }
+
+  if (typeof mapData !== "function" || mapData.length !== 1) {
+    throw new TypeError("mapData option expected to be a unary function");
+  }
+
+  if ("dataSrc" in opts) {
+    throw new TypeError(
+      "pleteWithFetchAndAbort does not use a dataSrc option, but uses urlTemplate and mapData options"
+    );
+  }
+
+  opts.dataSrc = fetchDataSrc.bind(
+    null,
+    window.fetch,
+    urlTemplate,
+    mapData,
+    fetchOptions
+  );
+  delete opts.urlTemplate;
+  delete opts.mapData;
+
+  return new Plete(opts);
+}

--- a/lib/plete-with-fetch-and-abort.test.js
+++ b/lib/plete-with-fetch-and-abort.test.js
@@ -1,0 +1,102 @@
+import { assert, sinon } from "@sinonjs/referee-sinon";
+import { loadDefault } from "./proxyquire-helper.js";
+
+function getOptions(overrides) {
+  return Object.assign(
+    {
+      mapData: function identity(data) {
+        return data;
+      },
+      urlTemplate: "{query}"
+    },
+    overrides
+  );
+}
+
+describe("pleteWithFetchAndAbort", function() {
+  beforeEach(function() {
+    this.fakePlete = sinon.fake.returns("ff7abd30-c066-43de-b71c-3b376a6bb564");
+    this.fakeFetchDataSrc = sinon.fake();
+
+    this.pleteWithFetchAndAbort = loadDefault(
+      "./plete-with-fetch-and-abort.js",
+      {
+        "./plete.js": this.fakePlete,
+        "./fetch-data-src.js": this.fakeFetchDataSrc
+      }
+    );
+  });
+
+  it("returns a Plete instance", function() {
+    const options = getOptions();
+    const result = this.pleteWithFetchAndAbort(options);
+
+    assert.isTrue(result instanceof this.fakePlete);
+  });
+
+  context("when called with an invalid urlTemplate option", function() {
+    it("throws an error", function() {
+      const t = this;
+      [undefined, "6def581d-fecf-4181-84e0-1e06d1b9e4ba"].forEach(function(
+        value
+      ) {
+        const options = getOptions({
+          urlTemplate: value
+        });
+
+        assert.exception(
+          function() {
+            t.pleteWithFetchAndAbort(options);
+          },
+          {
+            message:
+              "urlTemplate option expected to be a string containing '{query}'"
+          }
+        );
+      });
+    });
+  });
+
+  context("when called with an invalid mapData option", function() {
+    it("throws an error", function() {
+      const t = this;
+
+      [undefined, sinon.fake()].forEach(function(value) {
+        const options = getOptions({
+          mapData: value
+        });
+
+        assert.exception(
+          function() {
+            t.pleteWithFetchAndAbort(options);
+          },
+          {
+            message: "mapData option expected to be a unary function"
+          }
+        );
+      });
+    });
+  });
+
+  context("when called with a dataSrc option", function() {
+    it("throws an error", function() {
+      const t = this;
+
+      [[], sinon.fake()].forEach(function(value) {
+        const options = getOptions({
+          dataSrc: value
+        });
+
+        assert.exception(
+          function() {
+            t.pleteWithFetchAndAbort(options);
+          },
+          {
+            message:
+              "pleteWithFetchAndAbort does not use a dataSrc option, but uses urlTemplate and mapData options"
+          }
+        );
+      });
+    });
+  });
+});

--- a/lib/process-response.js
+++ b/lib/process-response.js
@@ -1,0 +1,12 @@
+export default processResponse;
+
+async function processResponse(promise, mapData, defaultResult) {
+  const response = await promise;
+  const result = await response.json();
+
+  if (!Array.isArray(result)) {
+    return defaultResult;
+  }
+
+  return mapData(result);
+}

--- a/lib/process-response.test.js
+++ b/lib/process-response.test.js
@@ -1,0 +1,31 @@
+import { sinon, assert } from "@sinonjs/referee-sinon";
+
+import processResponse from "./process-response.js";
+
+describe("processResponse", function() {
+  context("when result is not an array", function() {
+    it("it returns defaultResult", async function() {
+      const promise = Promise.resolve({
+        json: sinon.fake.resolves("b6ab9275-1cf5-4628-bdc3-f88c079dc73c")
+      });
+      const mapData = sinon.fake();
+      const defaultResult = "6dc49244-e791-45b3-92ef-5055ffde6285";
+      const result = await processResponse(promise, mapData, defaultResult);
+
+      assert.equals(result, defaultResult);
+    });
+  });
+  context("When result is an array", function() {
+    it("it returns mapData(result)", async function() {
+      const promise = Promise.resolve({
+        json: sinon.fake.resolves(["b6ab9275-1cf5-4628-bdc3-f88c079dc73c"])
+      });
+      const mapData = sinon.fake.returns(
+        "fe1961d8-f2ee-4c9f-8612-3385d69c18a2"
+      );
+      const result = await processResponse(promise, mapData);
+
+      assert.equals(result, mapData.returnValues[0]);
+    });
+  });
+});


### PR DESCRIPTION
This pull request adds a convenience factory for using `Plete` with [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API). It has feature detection of the  [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController), and uses it when available to cancel previous requests, ensuring that only the results of the last request are used.

#### Background

See

* https://github.com/mroderick/plete/issues/5
* https://itnext.io/how-you-can-abort-fetch-request-on-a-flight-830a639b9b92

#### Solution

Create a factory function to initialise `Plete` with `dataSrc` that uses `fetch` and `AbortController`.

```js
import pleteWithFetchAndAbort from "./lib/plete-with-fetch-and-abort.js";

function mapCountriesToPleteData(countries) {
  return countries.map(function(v) {
    return {
      id: v.alpha3Code,
      label: v.name
    };
  });
}

const plete = pleteWithFetchAndAbort({
  input: document.querySelector("#fetch-with-cancellation input[name='country']"),
  // a function to map the result to Plete's format
  mapData: mapCountriesToPleteData,
  select: function(id) {
    document.querySelector("#fetch-with-cancellation .selectedValue").textContent = id;
  },
  // a url template to plug the query into
  urlTemplate: "https://restcountries.eu/rest/v2/name/{query}"
});
```

#### How to verify

1. Check out this branch
1. Modify `fetch-data-src.js` and add a console statement inside the catch block
    ```js
    if (error.name === "AbortError") {
      console.log("Aborted a fetch request");
      return defaultResult;
    }
    ```
1. `npm start`
1. Access the development examples at http://localhost:8080
1. In the final example try to make overlapping requests by typing and observe that the aborted request is logged to the console. (This is really challenging to do with a stable internet connection and with a fast server).
1. Observe that `Plete` still works as normal