### PR TITLE
Code of Conduct and Contributing document

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by e-mailing any or all of [Morgan Roderick](mailto:morgan@roderick.dk). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior,  harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0,
+available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,118 @@
+# Contributing to Plete
+
+There are several ways of contributing to Plete
+
+* Look into [issues tagged `help-wanted`](https://github.com/mroderick/plete/issues?q=is%3Aopen+is%3Aissue+label%3A%22Help+wanted%22)
+* Help [improve the documentation](https://github.com/mroderick/plete/tree/master) published
+  at [the Plete documentation site](https://plete.dev). [Documentation issues](https://github.com/mroderick/plete/issues?q=is%3Aopen+is%3Aissue+label%3ADocumentation).
+* Help someone understand and use Plete on [Stack Overflow](https://stackoverflow.com/questions/tagged/plete-js)
+* Report an issue, please read instructions below
+* Help with triage of the [issues](https://github.com/mroderick/plete/issues). The clearer they are, the more likely they are to be fixed soon.
+* Contribute to the code base.
+
+## Contributor Code of Conduct
+
+Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+
+## Reporting an issue
+
+To save everyone time and make it much more likely for your issue to be understood, worked on and resolved quickly, it would help if you're mindful of [How to Report Bugs Effectively](http://www.chiark.greenend.org.uk/~sgtatham/bugs.html) when pressing the "Submit new issue" button.
+
+As a minimum, please report the following:
+
+* Which environment are you using?
+  * Browser
+  * OS
+* Which version of Plete?
+* How are you loading Plete?
+* What other libraries are you using?
+* What you expected to happen
+* What actually happens
+* Describe **with code** how to reproduce the fault
+
+See [our issue templates](https://github.com/mroderick/plete/blob/master/.github/) for all details.
+
+## Contributing to the code base
+
+Pick [an issue](https://github.com/mroderick/plete/issues) to fix, or pitch
+new features. To avoid wasting your time, please ask for feedback on feature
+suggestions with [an issue](https://github.com/mroderick/plete/issues/new/choose).
+
+Make sure you have read [GitHub's guide on forking](https://guides.github.com/activities/forking/). It explains the general contribution process and key concepts.
+
+### Making a pull request
+
+Please try to [write great commit messages](http://chris.beams.io/posts/git-commit/).
+
+There are numerous benefits to great commit messages
+
+* They allow Plete users to understand the consequences of updating to a newer version
+* They help contributors understand what is going on with the codebase, allowing features and fixes to be developed faster
+* They save maintainers time when compiling the changelog for a new release
+
+If you're already a few commits in by the time you read this, you can still [change your commit messages](https://help.github.com/articles/changing-a-commit-message/).
+
+Also, before making your pull request, consider if your commits make sense on their own (and potentially should be multiple pull requests) or if they can be squashed down to one commit (with a great message). There are no hard and fast rules about this, but being mindful of your readers greatly help you author good commits.
+
+### Use EditorConfig
+
+To save everyone some time, please use [EditorConfig](http://editorconfig.org), so your editor helps make
+sure we all use the same encoding, indentation, line endings, etc.
+
+### Installation
+
+The Plete developer environment requires Node/NPM & Git . Please make sure you have
+Node installed, and install the project dependencies:
+
+    $ npm install
+
+This will also install a pre-commit hook, that runs style validation on staged files.
+
+
+### Linting and style
+
+Plete uses [ESLint](http://eslint.org) to keep the codebase free of lint, and uses [Prettier](https://prettier.io) to keep consistent style.
+
+If you are contributing to the Plete project, you'll probably want to configure your editors ([ESLint](https://eslint.org/docs/user-guide/integrations#editors), [Prettier](https://prettier.io/docs/en/editors.html)) to make editing code a more enjoyable experience.
+
+The ESLint verification (which includes Prettier) will be run before unit tests in the CI environment. The build will fail if the source code does not pass the style check.
+
+
+You can run the linter locally:
+
+```
+$ npm run lint
+```
+
+You can fix a lot lint and style violations automatically:
+
+```
+$ npm run lint -- --fix
+```
+
+To ensure consistent reporting of lint warnings, you should use the same versions of ESLint and Prettier as defined in `package.json` (which is what the CI servers use).
+
+### Run the tests
+
+The command below runs tests
+
+    $ npm test
+
+### Code Coverage
+
+This repository requires 100%, line, branch and function coverage. For more information about code coverage please see [Wikipedia - Code Coverage](https://en.wikipedia.org/wiki/Code_coverage).
+
+Running the command to run all tests with coverage checking, produces a coverage report in both [lcov](http://ltp.sourceforge.net/coverage/lcov.php) and html formats; as well as providing verbose command line output.
+
+The command below runs tests with coverage
+
+    $ npm run test-check-coverage
+
+### Compiling a built version of the library
+
+Build requires Node.
+
+To build run
+
+    $ node run build
+


### PR DESCRIPTION
Following up from #54 this PR addresses contributing using prior work from https://github.com/sinonjs/sinon with changes to try to make it relevant, aim-to improve contributor understanding and healthy engagement.

This additionally includes a code of conduct, which if it should be split out. I feel should come prior to this PR merging. I've made that a separate commit to make it easier to pull-out if needed.

Following this PR, if acceptable, I'd intend to approach the pull request template.

### Differences with Sinon.JS

* Points of contact for the code of contact are just you for-now Morgan
* References to browserify have been removed
* References to compatibility document have been removed
* Environment has been clarified to Browser and OS. AFAIK consumers will always run in a browser
* Added a section pointing to coverage policy and generated output(s)
* Checked all links
* Adjusted some sentence structure.